### PR TITLE
Fix the handling of tags when creating new Articles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
 # copy csproj and restore as distinct layers
@@ -25,7 +25,7 @@ RUN pwd
 RUN dotnet publish "src/Api/Api.csproj" -c Release --no-build -o app
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 
 WORKDIR /app
 COPY --from=publish /app ./

--- a/src/Data/Services/ConduitRepository.cs
+++ b/src/Data/Services/ConduitRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -56,15 +56,21 @@ public class ConduitRepository(ConduitContext context) : IConduitRepository
     {
         var dbTags = await context.Tags.Where(x => tags.Contains(x.Id)).ToListAsync(cancellationToken);
 
+        bool didCreateNewTag = false;
         foreach (var tag in tags)
         {
             if (!dbTags.Exists(x => x.Id == tag))
             {
                 context.Tags.Add(new Tag(tag));
+                didCreateNewTag = true;
             }
         }
-
-        return context.Tags;
+        if (didCreateNewTag)
+        {
+            context.SaveChanges();
+            dbTags = await context.Tags.Where(x => tags.Contains(x.Id)).ToListAsync(cancellationToken);
+        }
+        return dbTags;
     }
 
     public async Task SaveChangesAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
The handling of tags is broken when adding new Articles. 
It did create the tags but added all existing tags to the new article instead of the requested tags.